### PR TITLE
fix: 25x decode slowdown on discrete AMD GPUs from zero-copy mmap

### DIFF
--- a/patches/llama/0008-metal-mmap-unified-gate.patch
+++ b/patches/llama/0008-metal-mmap-unified-gate.patch
@@ -1,0 +1,30 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal.cpp b/ggml/src/ggml-metal/ggml-metal.cpp
+index 0445c30c6..ca47f3c60 100644
+--- a/ggml/src/ggml-metal/ggml-metal.cpp
++++ b/ggml/src/ggml-metal/ggml-metal.cpp
+@@ -737,20 +737,24 @@ static enum ggml_backend_dev_type ggml_backend_metal_device_get_type(ggml_backen
+ 
+ static void ggml_backend_metal_device_get_props(ggml_backend_dev_t dev, ggml_backend_dev_props * props) {
+     props->name        = ggml_backend_metal_device_get_name(dev);
+     props->description = ggml_backend_metal_device_get_description(dev);
+     props->type        = ggml_backend_metal_device_get_type(dev);
+ 
+     ggml_backend_metal_device_get_memory(dev, &props->memory_free, &props->memory_total);
+ 
++    // zero-copy only loses when the fallback would be private VRAM: on a discrete GPU a mapped weight buffer streams weights over PCIe on every access (~25x slower decode).
++    // eGPUs default to shared buffers (#17866), so their fallback is shared memory too and they keep zero-copy.
++    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props((ggml_metal_device_t) dev->context);
++
+     props->caps = {
+         /* .async                = */ true,
+         /* .host_buffer          = */ false,
+-        /* .buffer_from_host_ptr = */ true,
++        /* .buffer_from_host_ptr = */ props_dev->has_unified_memory || props_dev->use_shared_buffers,
+         /* .events               = */ true,
+         /* .mmap_support         = */ true,
+     };
+ }
+ 
+ static ggml_backend_t ggml_backend_metal_device_init_backend(ggml_backend_dev_t dev, const char * params) {
+     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)dev->context;
+ 


### PR DESCRIPTION
# fix: 25x decode slowdown on discrete AMD GPUs from zero-copy mmap

## TL;DR

On Macs with discrete GPUs (no unified memory — Mac Pro + Radeon Pro W5700X or Vega II/Duo, any Intel Mac + AMD dGPU), loading a model with mmap (the default) maps the weights as **Shared (system-memory) Metal buffers**. Every decode GEMV then streams weights over PCIe at ~6 GB/s instead of reading VRAM at ~700 GB/s. Measured: **2.41 t/s** decode on 4× Radeon Pro Vega II Duo where the same model, engine and silicon does **~60 t/s**. A one-expression gate fixes it: only advertise `buffer_from_host_ptr` when the loader's fallback would not be a Private VRAM buffer.

One patch: `patches/llama/metal/0078-metal-mmap-unified-gate.patch` (renumber freely).

## Root cause

`ggml_backend_metal_device_get_props` advertised `caps.buffer_from_host_ptr = true` unconditionally. The model loader (`src/llama-model.cpp`: `ml.use_mmap && buffer_from_host_ptr_supported && is_default_buft`) then creates the weight buffers via `ggml_backend_dev_buffer_from_host_ptr` → `ggml_metal_buffer_map` → `newBufferWithBytesNoCopy(..., MTLResourceStorageModeShared, ...)`.

That zero-copy path is the right thing on Apple Silicon — unified memory is what it was designed for (the loader comment even says so). On discrete GPUs, Shared storage is host RAM: every kernel's weight reads cross PCIe, every dispatch, every token, forever.

## Evidence

Rig: 2× Radeon Pro Vega II Duo (4× gfx906 dies, 2 Infinity Fabric peer groups), Mac Pro 2019, macOS 26.6.2. Model: gemma-3-4b-it Q4_K_M, `-ngl 99 -fa auto -p 512 -n 128`.

Diagnosis arc (so the "why" is not just one number):

1. **Symptom**: 2.41 t/s decode, with device-side GPU timestamps showing the GPU genuinely busy 404 ms/token (~0.5 ms per kernel across ~821 dispatches).
2. **Hardware exonerated** by a purpose-built dispatch microbenchmark (chains of N dispatches in one command buffer): raw dispatch cost 1.4 µs; a streaming GEMV kernel from a Private buffer sustains **687–723 GB/s = 69–72% of 1 TB/s HBM2** on every die; PCIe x16 gen3 both modules; 61–62 °C, no throttling. The card is healthy — kernels are waiting on data, not compute.
3. **Mechanism confirmed**: verbose logs show weight buffers allocated via the host-ptr (Shared) path; `--mmap 0` (force copy to VRAM) immediately restores **59.41 t/s** single-die.
4. **Fix verified**: **57.71 t/s** single-die with mmap **on** (was 2.41), **45.84 t/s** on 4 dies; pp512 1313. Matches an independent reference box (60.49 t/s, same engine version, single Vega II Duo — see PR #71 thread).

Same ~2 t/s signature was previously observed on the W5700X pair — this bug predates the card swap and plausibly explains earlier "box-wide GPU decode degradation" reports from mmap clients. Related upstream issue: ggml-org/llama.cpp#15228.

## The fix

```cpp
/* .buffer_from_host_ptr = */ props_dev->has_unified_memory || props_dev->use_shared_buffers,
```

Zero-copy only loses when the loader's fallback would be a Private VRAM buffer:

- **Apple Silicon (unified memory)**: keeps zero-copy. Unchanged.
- **Built-in discrete** (`use_shared_buffers = false`): cap disabled → loader allocates Private + copies once at load → full HBM2 speed. **This is the fix.**
- **eGPU** (defaults to Shared buffers since upstream PR ggml-org/llama.cpp#17866): the fallback would be Shared anyway → keeps zero-copy; no added copy, no behavior change.
- `GGML_METAL_SHARED_BUFFERS_DISABLE` on any host → fallback is Private → cap disabled → fixed path.

## Why this is correct

- The only consumer of `caps.buffer_from_host_ptr` is the model loader's mmap path; with it false, the loader takes the ordinary allocate-and-copy route — identical to `--mmap 0`, which measured full speed.
- `ggml-backend-meta` AND-merges the cap across devices, so mixed systems resolve to false (allocation) — the safe choice.
- No ABI change; unified-memory behavior is byte-identical.

## Test matrix (Vega II Duo rig, macOS 26.6.2, engine 0.85.9 + series)

| config | before | after |
|---|---|---|
| single die, mmap on (default) | 2.41 t/s | **57.71 t/s** |
| 4 dies, mmap on | ~2.2 t/s (with stalls) | **45.84 t/s** |
| 4 dies, `--mmap 0` (control) | 42.25 t/s | unchanged |
| 4 dies, `-ts 1/1/1/1 --mmap 0` | — | 42.91 t/s, layers spread 9/9/9/8 |
| MoE ON / OFF builds | — | both compile + run |

Patch series applies clean on v0.85.10 (after 0057/0058/0077). Independent GPT-5.6-sol code review: initial CHANGES (eGPU scoping) → addressed by the `use_shared_buffers` disjunct → **APPROVE**.

## Notes

- This is an **inherited llama.cpp bug** (the mmap zero-copy path is upstream's), which is why I framed it as a capability gate rather than a ToshLLM-specific workaround. I intend to submit the same fix to ggml-org; if you'd rather wait for that instead of carrying the patch, drop this PR — but every Intel-Mac + dGPU user loading with mmap currently pays ~25x, and the GUI loads with mmap by default.
- Artifacts (telemetry `.ttle`, microbenchmark JSON, run logs) available on request.
