### PR TITLE
fix: Metal multi-GPU correctness for >=3 devices (allreduce, synchronize, peer gate, queue depth)

### DIFF
--- a/patches/llama/metal/0079-metal-comm-allreduce-fail-loud.patch
+++ b/patches/llama/metal/0079-metal-comm-allreduce-fail-loud.patch
@@ -1,0 +1,79 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal.cpp b/ggml/src/ggml-metal/ggml-metal.cpp
+index c492f07..1bae359 100644
+--- a/ggml/src/ggml-metal/ggml-metal.cpp
++++ b/ggml/src/ggml-metal/ggml-metal.cpp
+@@ -1084,17 +1084,27 @@ static bool ggml_backend_metal_comm_allreduce_tensor(void * comm_ctx_v, ggml_ten
+     bool reduced = false;
+     auto push = [&](size_t j_src, size_t j_dst, size_t step, bool hold) {
+         view_tmp(j_dst, step);
+         const bool ok = ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j_dst],
+                                                               tensors[j_src], &tmp[j_dst], prefer_events, hold);
+-        GGML_ASSERT(ok || !reduced);
++        if (!ok && reduced) {
++            // the partial sums are already folded in, so the fallback would add them a
++            // second time - a failed butterfly has no safe way out
++            GGML_ABORT("%s: allreduce push failed after partial reduction\n", __func__);
++        }
+         return ok;
+     };
+     auto reduce = [&](size_t j_dst) {
+         ggml_metal_t ctx = (ggml_metal_t) comm_ctx->backends[j_dst]->context;
+-        GGML_ASSERT(ggml_metal_add_inplace_async(ctx, tensors[j_dst], &tmp[j_dst]));
++        if (!ggml_metal_add_inplace_async(ctx, tensors[j_dst], &tmp[j_dst])) {
++            if (reduced) {
++                GGML_ABORT("%s: allreduce add failed after partial reduction\n", __func__);
++            }
++            return false;
++        }
+         reduced = true;
++        return true;
+     };
+ 
+     const size_t offset_max = ggml_backend_metal_comm_offset_max(n_backends);
+ 
+     size_t step = 0;
+@@ -1103,11 +1113,13 @@ static bool ggml_backend_metal_comm_allreduce_tensor(void * comm_ctx_v, ggml_ten
+             if (!push(j_src, j_src - 2*offset_max, step, hold_dst)) {
+                 return false;
+             }
+         }
+         for (size_t j_src = 2*offset_max; j_src < n_backends; j_src++) {
+-            reduce(j_src - 2*offset_max);
++            if (!reduce(j_src - 2*offset_max)) {
++                return false;
++            }
+         }
+         step++;
+     }
+ 
+     // Every exchange of a step must read the partner's tensor before its own add rewrites it,
+@@ -1117,20 +1129,25 @@ static bool ggml_backend_metal_comm_allreduce_tensor(void * comm_ctx_v, ggml_ten
+             if (!push(j, j ^ offset, step, hold_dst)) {
+                 return false;
+             }
+         }
+         for (size_t j = 0; j < 2*offset_max; j++) {
+-            reduce(j);
++            if (!reduce(j)) {
++                return false;
++            }
+         }
+         step++;
+     }
+ 
+     for (size_t j = 2*offset_max; j < n_backends; j++) {
+         const size_t j_src = j - 2*offset_max;
+-        GGML_ASSERT(ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j],
+-                                                          tensors[j_src], tensors[j], prefer_events,
+-                                                          /*hold_dst =*/ false));
++        // past the reduction, so there is no fallback left if this copy fails
++        if (!ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j],
++                                                    tensors[j_src], tensors[j], prefer_events,
++                                                    /*hold_dst =*/ false)) {
++            GGML_ABORT("%s: allreduce tail copy failed\n", __func__);
++        }
+     }
+ 
+     return true;
+ }
+ 

--- a/patches/llama/metal/0080-metal-sync-flush-pending-waits.patch
+++ b/patches/llama/metal/0080-metal-sync-flush-pending-waits.patch
@@ -1,0 +1,24 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-context.m b/ggml/src/ggml-metal/ggml-metal-context.m
+index 4c84fec..29b2644 100644
+--- a/ggml/src/ggml-metal/ggml-metal-context.m
++++ b/ggml/src/ggml-metal/ggml-metal-context.m
+@@ -478,10 +478,19 @@ const char * ggml_metal_get_name(ggml_metal_t ctx) {
+ 
+ void ggml_metal_synchronize(ggml_metal_t ctx) {
+     // nothing completes while a command buffer is still held open
+     ggml_metal_cmd_buf_hold_flush(ctx);
+ 
++    // pending waits guard memory a peer blit can still be reading, so they must run and complete before synchronize returns
++    if (ctx->n_ev_wait_pending > 0 || ctx->n_peer_waits > 0) {
++        @autoreleasepool {
++            id<MTLCommandBuffer> cmd_buf = [ctx->queue commandBuffer];
++            ggml_metal_encode_pending_waits(ctx, cmd_buf);
++            ggml_metal_cmd_buf_submit(ctx, cmd_buf);
++        }
++    }
++
+     // wait for any backend operations to finish
+     if (ctx->cmd_buf_last) {
+         [ctx->cmd_buf_last waitUntilCompleted];
+         ctx->cmd_buf_last = nil;
+     }

--- a/patches/llama/metal/0081-metal-peer-gate-pair-only.patch
+++ b/patches/llama/metal/0081-metal-peer-gate-pair-only.patch
@@ -1,0 +1,19 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-context.m b/ggml/src/ggml-metal/ggml-metal-context.m
+index 29b2644..1903da0 100644
+--- a/ggml/src/ggml-metal/ggml-metal-context.m
++++ b/ggml/src/ggml-metal/ggml-metal-context.m
+@@ -860,11 +860,13 @@ static bool ggml_metal_cpy_xdev_peer(ggml_metal_t ctx_src, ggml_metal_t ctx_dst,
+     if (@available(macOS 10.15, *)) {
+         id<MTLDevice> dev_src = ggml_metal_device_get_obj(ctx_src->dev);
+         id<MTLDevice> dev_dst = ggml_metal_device_get_obj(ctx_dst->dev);
+         const bool same_dev = dev_src == dev_dst && ggml_metal_peer_self();
+         const uint64_t peer_group = dev_src.peerGroupID;
+-        if (!same_dev && (peer_group == 0 || peer_group != dev_dst.peerGroupID)) {
++        // a peer group wider than a pair can span PCIe-only links, so gate on IFL pairs
++        if (!same_dev && (peer_group == 0 || peer_group != dev_dst.peerGroupID ||
++                          dev_src.peerCount != 2 || dev_dst.peerCount != 2)) {
+             return false;
+         }
+ 
+         struct ggml_metal_buffer_id bid_src = ggml_metal_get_buffer_id(src);
+         struct ggml_metal_buffer_id bid_dst = ggml_metal_get_buffer_id(dst);

--- a/patches/llama/metal/0082-metal-queue-depth-scale.patch
+++ b/patches/llama/metal/0082-metal-queue-depth-scale.patch
@@ -1,0 +1,56 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index b97b4c7..b9131e3 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -788,20 +788,47 @@ static enum ggml_metal_device_id ggml_metal_device_id_parse(const char * name) {
+         }
+     }
+     return GGML_METAL_DEVICE_GENERIC;
+ }
+ 
++// registered slot count, mirroring ggml_backend_metal_reg: GGML_METAL_DEVICES=K, or one slot per GGML_METAL_DEVICE_LIST entry
++static int ggml_metal_device_registered_count(void) {
++    int n = 1;
++    const char * env_num = getenv("GGML_METAL_DEVICES");
++    if (env_num) {
++        n = atoi(env_num);
++    }
++    const char * env_list = getenv("GGML_METAL_DEVICE_LIST");
++    if (env_list && *env_list) {
++        n = 1;
++        for (const char * p = env_list; *p; ++p) {
++            if (*p == ',') {
++                ++n;
++            }
++        }
++    }
++    return n;
++}
++
+ // macOS can hand out an integrated iGPU (isLowPower, ~1 GB) as the system
+ // default. Auto-selection skips it; explicit DEVICE_INDEX/LIST can still pin it.
+ // tensor split blocks the main thread on the queue's in-flight command buffer limit (64 by
+-// default), so allow raising it: TOSH_MTL_QUEUE_DEPTH
++// default), so scale it with the registered device count; TOSH_MTL_QUEUE_DEPTH overrides
+ static id<MTLCommandQueue> ggml_metal_new_queue(id<MTLDevice> device) {
+     const char * s = getenv("TOSH_MTL_QUEUE_DEPTH");
+-    const int depth = s ? atoi(s) : 0;
+ 
+-    if (depth > 0) {
+-        return [device newCommandQueueWithMaxCommandBufferCount:depth];
++    if (s != NULL) {
++        const int depth = atoi(s);
++        if (depth > 0) {
++            return [device newCommandQueueWithMaxCommandBufferCount:depth];
++        }
++        return [device newCommandQueue];
++    }
++
++    const int n_dev = ggml_metal_device_registered_count();
++    if (n_dev > 2) {
++        return [device newCommandQueueWithMaxCommandBufferCount:64 * ((n_dev + 1) / 2)];
+     }
+ 
+     return [device newCommandQueue];
+ }
+ 


### PR DESCRIPTION
# fix: Metal multi-GPU correctness for ≥3 devices (allreduce, synchronize, peer gate, queue depth)

## TL;DR

Four small, independent correctness fixes to the Metal multi-GPU path, found by static review plus live testing on the first rig to actually exercise that machinery: **2× Radeon Pro Vega II Duo** (4 gfx906 dies, 2 Infinity Fabric peer groups). On the previous 2× W5700X setup both cards reported `peerGroupID == 0`, so the peer/cross-device code **never executed**. With 0057 routing more traffic through these paths, these are the correctness floor.

Patches (renumber freely): `0079` allreduce fail-loud, `0080` synchronize flush, `0081` peer IFL gate, `0082` queue-depth scaling. Series applies clean on v0.85.10.

## 0079 — comm allreduce: fail loud instead of silently wrong results

`GGML_ASSERT(ok || !reduced)` in the butterfly allreduce vanishes under NDEBUG. If a push fails **after** `reduce()` has partially run, the function returns false and the meta-backend fallback re-adds the partial sums a second time — silently wrong output. The n>2 butterfly (newly exercised at 4 devices) issues 8 pushes instead of 2, quadrupling that window.

Fix: `return false` (safe fallback, which redoes the whole allreduce) only when **nothing** was reduced; once any device has reduced, `GGML_ABORT`. The comm interface's bool contract offers no other channel, and wrong results are never acceptable. The same treatment covers the reduce loop and the tail copies to excess devices — all three were the same latent NDEBUG pattern.

## 0080 — synchronize: flush pending peer/event waits

`ggml_metal_peer_wait_add` queues back-edge waits into the source context's **next** command buffer, but `ggml_metal_synchronize` flushed only `cmd_buf_hold` and waited `cmd_buf_last`. A synchronize could therefore return while a peer blit on another die still reads this context's memory — a host-side free/realloc (MoE staging resize, buffer churn) then races the in-flight remote read.

Fix: when pending waits exist, encode them into a small command buffer (the existing `ggml_metal_encode_pending_waits` + submit pattern) and include it in the wait. Deadlock-free by construction: every queued wait targets an event already signaled by a committed buffer (checked at all signal/wait sites); encoding clears the pending lists so nothing is encoded twice; empty lists skip the extra buffer entirely (behavior unchanged).

## 0081 — peer copies: require true IFL pairs (`peerCount == 2`)

The peer blit path (`newRemoteBufferViewForDevice`) gated only on `peerGroupID != 0 && equal`. The code itself marks peer opt-in "until validated on bridged hardware: a success that silently returns wrong data has no fallback." A peer group with more than 2 devices can span PCIe-only links, where remote views are unvalidated.

Fix: additionally require `peerCount == 2` on both endpoints. Verified live on the dual-module rig: both peer groups report count=2 and both pairs log `Infinity Fabric peer transfer enabled`; cross-module (PCIe-only) pairs correctly fall back.

## 0082 — queue depth scales with registered device count

Command queues default to 64 in-flight buffers; with >2 devices, split + allreduce staging + prefetch can exhaust that and backpressure-stall the single driving thread (the code's own comment flags tensor split blocking on this limit).

Fix: when `TOSH_MTL_QUEUE_DEPTH` is unset and **registered** devices > 2, create the queue with `64 * ceil(n/2)`. The count mirrors the `GGML_METAL_DEVICES` / `GGML_METAL_DEVICE_LIST` registration parsing (not physical count); `TOSH_MTL_QUEUE_DEPTH=0` keeps its prior default-queue behavior, positive values unchanged. Benchmark-neutral on this rig (±10% run variance swamps any effect) — this is insurance, not a perf claim.

## Testing (4× gfx906, macOS 26.6.2, gemma-3-4b Q4_K_M, `-p 512 -n 128`)

| config | result |
|---|---|
| 4 dies, mmap on | 44–50 t/s tg128, completes, no regression vs pre-patch baseline (>3% threshold) |
| 4 dies, `-ts 1/1/1/1 --mmap 0` | completes, layers spread 9/9/9/8 |
| 2 dies IFL pair + `TOSH_MGPU_PEER=1` | 53.0 t/s, peer enabled both pairs |
| 2 dies cross-module (PCIe) | completes |
| 4 dies, `TOSH_MGPU_PEER=1 TOSH_MGPU_EVENTS=1` | completes |

Series validation: all patches apply clean on v0.85.10 — 0079 lands after 0057's allreduce-threshold refactor with a small offset, no conflict.

Independent GPT-5.6-sol code reviews per patch: **APPROVE** ×3 (0079, 0080 after a comment-style fix, 0081); 0082 initial CHANGES (registered-count basis, ceiling division, env=0 precedence) → all addressed → **APPROVE**.

## Notes

- These are deliberately minimal: each is a few lines, no behavior change on ≤2 devices, and the previously-dead paths are the only ones touched.
- Complementary to 0057/0058: as peer traffic moves toward default-on, the failure modes fixed here stop being theoretical.
- The 4-die test rig's telemetry artifacts (`.ttle` per run) available on request.
