### PR TITLE
fix: build with TOSH_ENABLE_DYNAMIC_MOE=OFF (llama-graph + metal stubs)

### DIFF
--- a/patches/llama/core/0083-moe-fixed-of-stub.patch
+++ b/patches/llama/core/0083-moe-fixed-of-stub.patch
@@ -1,0 +1,16 @@
+diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
+index 694a2e0..f7551aa 100644
+--- a/src/llama-graph.cpp
++++ b/src/llama-graph.cpp
+@@ -7,10 +7,11 @@ static inline ggml_tensor * tosh_moe_bank_of(ggml_tensor * t) {
+ }
+ #else
+ static inline const void * tosh_moe_state_of(const void *) { return nullptr; }
+ static inline const void * tosh_moe_ram_of(const void *)   { return nullptr; }
+ static inline int tosh_moe_experts_of(const void *)         { return 0; }
++static inline int tosh_moe_fixed_of(const void *)           { return 0; }
+ static inline int tosh_moe_ids_room(int) { return 0; }
+ static inline ggml_tensor * tosh_moe_bank_of(ggml_tensor * t) { return t; }
+ #endif
+ 
+ #include "llama-impl.h"

--- a/patches/llama/metal/0084-metal-moe-off-stubs.patch
+++ b/patches/llama/metal/0084-metal-moe-off-stubs.patch
@@ -1,0 +1,76 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-ops.cpp b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+index 4f4fef8..2c53d67 100644
+--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
++++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+@@ -8,10 +8,20 @@ static inline const void * tosh_moe_ram_of(const void *)   { return nullptr; }
+ static inline const void * tosh_moe_slots_of(const void *) { return nullptr; }
+ static inline const void * tosh_moe_stage(void)            { return nullptr; }
+ static inline int tosh_moe_experts_of(const void *)         { return 0; }
+ static inline int tosh_moe_fixed_of(const void *)           { return 0; }
+ static inline bool tosh_moe_should_route(const void *, int) { return false; }
++static inline int tosh_moe_ids_room(int)                   { return 0; }
++static inline int tosh_moe_off_slot_for_id(int, int, int)  { return 0; }
++static inline int tosh_moe_off_cold_for_id(int, int, int)  { return 0; }
++static inline int tosh_moe_off_id_of_slot(int, int, int)   { return 0; }
++static inline int tosh_moe_off_usage(int, int, int)        { return 0; }
++static inline int tosh_moe_off_step(int, int, int)         { return 0; }
++static inline int tosh_moe_off_n_indices(int, int, int)    { return 0; }
++static inline int tosh_moe_off_evict(int, int, int)        { return 0; }
++static inline int tosh_moe_off_src(int, int, int)          { return 0; }
++static inline int tosh_moe_off_ids(int, int, int)          { return 0; }
+ #endif
+ 
+ #include "ggml.h"
+ #include "ggml-impl.h"
+ #include "ggml-backend-impl.h"
+diff --git a/ggml/src/ggml-metal/ggml-metal-context.m b/ggml/src/ggml-metal/ggml-metal-context.m
+index ba3736a..4c84fec 100644
+--- a/ggml/src/ggml-metal/ggml-metal-context.m
++++ b/ggml/src/ggml-metal/ggml-metal-context.m
+@@ -1268,10 +1268,11 @@ bool ggml_metal_add_inplace_async(ggml_metal_t ctx, struct ggml_tensor * acc, co
+     }
+ 
+     return true;
+ }
+ 
++#ifdef TOSH_ENABLE_DYNAMIC_MOE
+ static bool ggml_metal_moe_encode_range(
+         ggml_metal_t ctx, struct ggml_cgraph * gf, id<MTLCommandBuffer> cmd_buf, int start, int end) {
+     if (start >= end) {
+         return true;
+     }
+@@ -1837,20 +1838,22 @@ done:
+     ggml_metal_op_cached_moe_ids_clear();
+     ggml_metal_op_cached_moe_full_clear();
+     ctx->cmd_buf_last = nil;
+     return result;
+ }
++#endif
+ 
+ enum ggml_status ggml_metal_graph_compute(ggml_metal_t ctx, struct ggml_cgraph * gf) {
+     // command buffers run in commit order, so a held one has to go in before this graph
+     ggml_metal_cmd_buf_hold_flush(ctx);
+ 
+     if (ctx->has_error) {
+         GGML_LOG_ERROR("%s: backend is in error state from a previous command buffer failure - recreate the backend to recover\n", __func__);
+         return GGML_STATUS_FAILED;
+     }
+ 
++#ifdef TOSH_ENABLE_DYNAMIC_MOE
+     bool staged_moe = false;
+     const char * bounded_env = getenv("TOSH_MOE_BOUNDED_STAGE");
+     const bool bounded_requested = bounded_env != NULL && strcmp(bounded_env, "0") != 0;
+     const char * force_env = getenv("TOSH_MOE_BOUNDED_STAGE_FORCE");
+     const bool bounded_forced = force_env != NULL && strcmp(force_env, "0") != 0;
+@@ -1897,10 +1900,11 @@ enum ggml_status ggml_metal_graph_compute(ggml_metal_t ctx, struct ggml_cgraph *
+                 __func__, bounded_bank_size/(1024.0*1024.0*1024.0),
+                 bounded_threshold/(1024.0*1024.0*1024.0));
+             logged_fast = true;
+         }
+     }
++#endif
+ 
+     // number of nodes encoded by the main thread (empirically determined)
+     const int n_main = MAX(64, 0.1*gf->n_nodes);
+ 
+     // number of threads in addition to the main thread


### PR DESCRIPTION
# fix: build with TOSH_ENABLE_DYNAMIC_MOE=OFF (llama-graph + metal stubs)

## TL;DR

`TOSH_ENABLE_DYNAMIC_MOE` defaults to OFF, but the series doesn't compile in that configuration: `0075` calls `tosh_moe_fixed_of()` in `llama-graph.cpp` without a non-MoE stub, and the 0070–0076 Metal code uses ten `tosh_moe_*` helpers plus the `bounded_moe_*` context members that only exist under the ifdef. Two patches add the missing stubs and guards. Both configs now build on macOS and Linux.

Patches (renumber freely): `patches/llama/core/0083-moe-fixed-of-stub.patch`, `patches/llama/metal/0084-metal-moe-off-stubs.patch`.

## What breaks with OFF

- **`src/llama-graph.cpp`** (from 0075): calls `tosh_moe_fixed_of()`, which is missing from the existing `#else` stub block. Breaks every non-MoE build, any OS — found first on a Linux/CUDA build of the vendored tree.
- **`ggml/src/ggml-metal/ggml-metal-ops.cpp`** (from 0070–0076): uses `tosh_moe_ids_room`, `tosh_moe_off_slot_for_id`, `tosh_moe_off_cold_for_id`, `tosh_moe_off_id_of_slot`, `tosh_moe_off_usage`, `tosh_moe_off_step`, `tosh_moe_off_n_indices`, `tosh_moe_off_evict`, `tosh_moe_off_src`, `tosh_moe_off_ids`. The real inlines live in `tosh-moe/tosh-moe.h`, which is only included under the ifdef; the `#else` stub block didn't cover them.
- **`ggml/src/ggml-metal/ggml-metal-context.m`**: `ggml_metal_graph_compute_moe_staged` and its helpers use `bounded_moe_*` struct members that only exist under the ifdef.

## The fix

- **0083**: one-line `tosh_moe_fixed_of` stub in the existing `#else` block, matching its style.
- **0084**: ten return-0 stub inlines matching the `tosh-moe.h` signatures, plus `#ifdef TOSH_ENABLE_DYNAMIC_MOE` around the bounded-staging functions and their call site. No faked struct members; the guarded path is unreachable under OFF (`ggml_metal_op_cached_moe_host` always returns NULL there).

## Why it's safe

Every stubbed call site sits in a runtime-dead branch under OFF (guarded by the empty staged-ids/full-cold maps and `tosh_moe_state_of() == nullptr`), so a return-0 cannot alter behavior. ON builds compile the same code as before; the only change is that OFF-only-dead code is now also inside ifdefs.

## Testing

- macOS 26.6.2, CLT 26.6: **MoE ON and MoE OFF both build 100%**, zero errors.
- OFF runtime smoke (gemma-3-4b Q4_K_M, single Vega II Duo die): **58.68 t/s tg128** — identical to ON.
- Linux (CUDA) build of the full series also green — that's where 0083 was first needed.
- Independent GPT-5.6-sol review: **APPROVE** (stub signatures match the header, call sites runtime-dead under OFF, ON unchanged).

## Notes

- Why it matters even if you always build with MoE ON: the option ships **default OFF**, so CI, downstream forks, and first-time builders hit this immediately. 0083 additionally unblocks non-macOS builds of the vendored engine entirely.
- Series applies clean on v0.85.10.
