### PR TITLE
fix: Metal allreduce fail-loud + synchronize pending-wait flush

### DIFF
--- a/patches/llama/0008-metal-comm-allreduce-fail-loud.patch
+++ b/patches/llama/0008-metal-comm-allreduce-fail-loud.patch
@@ -1,0 +1,88 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal.cpp b/ggml/src/ggml-metal/ggml-metal.cpp
+index ca47f3c60..ae80721e6 100644
+--- a/ggml/src/ggml-metal/ggml-metal.cpp
++++ b/ggml/src/ggml-metal/ggml-metal.cpp
+@@ -1117,59 +1117,76 @@ static bool ggml_backend_metal_comm_allreduce_tensor(void * comm_ctx_v, ggml_ten
+ 
+     // Bailing out is only safe while no device has reduced anything: past that the generic
+     // path would add the partial sums a second time.
+     bool reduced = false;
+     auto push = [&](size_t j_src, size_t j_dst, size_t step, bool hold) {
+         view_tmp(j_dst, step);
+         const bool ok = ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j_dst],
+                                                               tensors[j_src], &tmp[j_dst], prefer_events, hold);
+-        GGML_ASSERT(ok || !reduced);
++        if (!ok && reduced) {
++            // the partial sums are already folded in, so the fallback would add them a
++            // second time - a failed butterfly has no safe way out
++            GGML_ABORT("%s: allreduce push failed after partial reduction\n", __func__);
++        }
+         return ok;
+     };
+     auto reduce = [&](size_t j_dst) {
+         ggml_metal_t ctx = (ggml_metal_t) comm_ctx->backends[j_dst]->context;
+-        GGML_ASSERT(ggml_metal_add_inplace_async(ctx, tensors[j_dst], &tmp[j_dst]));
++        if (!ggml_metal_add_inplace_async(ctx, tensors[j_dst], &tmp[j_dst])) {
++            if (reduced) {
++                GGML_ABORT("%s: allreduce add failed after partial reduction\n", __func__);
++            }
++            return false;
++        }
+         reduced = true;
++        return true;
+     };
+ 
+     const size_t offset_max = ggml_backend_metal_comm_offset_max(n_backends);
+ 
+     size_t step = 0;
+     if (n_backends > 2*offset_max) {
+         for (size_t j_src = 2*offset_max; j_src < n_backends; j_src++) {
+             if (!push(j_src, j_src - 2*offset_max, step, hold_dst)) {
+                 return false;
+             }
+         }
+         for (size_t j_src = 2*offset_max; j_src < n_backends; j_src++) {
+-            reduce(j_src - 2*offset_max);
++            if (!reduce(j_src - 2*offset_max)) {
++                return false;
++            }
+         }
+         step++;
+     }
+ 
+     // Every exchange of a step must read the partner's tensor before its own add rewrites it,
+     // so the copies all go out before any of the adds.
+     for (size_t offset = offset_max; offset >= 1; offset /= 2) {
+         for (size_t j = 0; j < 2*offset_max; j++) {
+             if (!push(j, j ^ offset, step, hold_dst)) {
+                 return false;
+             }
+         }
+         for (size_t j = 0; j < 2*offset_max; j++) {
+-            reduce(j);
++            if (!reduce(j)) {
++                return false;
++            }
+         }
+         step++;
+     }
+ 
+     for (size_t j = 2*offset_max; j < n_backends; j++) {
+         const size_t j_src = j - 2*offset_max;
+-        GGML_ASSERT(ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j],
+-                                                          tensors[j_src], tensors[j], prefer_events,
+-                                                          /*hold_dst =*/ false));
++        // past the reduction, so there is no fallback left if this copy fails
++        if (!ggml_backend_metal_cpy_tensor_async_ex(comm_ctx->backends[j_src], comm_ctx->backends[j],
++                                                    tensors[j_src], tensors[j], prefer_events,
++                                                    /*hold_dst =*/ false)) {
++            GGML_ABORT("%s: allreduce tail copy failed\n", __func__);
++        }
+     }
+ 
+     return true;
+ }
+ 
+ static ggml_backend_buffer_type_t * ggml_backend_metal_device_get_extra_bufts(ggml_backend_dev_t device) {
+     ggml_metal_device_t ctx_dev = (ggml_metal_device_t) device->context;
+ 

--- a/patches/llama/0009-metal-sync-flush-pending-waits.patch
+++ b/patches/llama/0009-metal-sync-flush-pending-waits.patch
@@ -1,0 +1,30 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-context.m b/ggml/src/ggml-metal/ggml-metal-context.m
+index 8e8dcb8d4..5ef272ec2 100644
+--- a/ggml/src/ggml-metal/ggml-metal-context.m
++++ b/ggml/src/ggml-metal/ggml-metal-context.m
+@@ -445,16 +445,25 @@ void ggml_metal_free(ggml_metal_t ctx) {
+ const char * ggml_metal_get_name(ggml_metal_t ctx) {
+     return ctx->name;
+ }
+ 
+ void ggml_metal_synchronize(ggml_metal_t ctx) {
+     // nothing completes while a command buffer is still held open
+     ggml_metal_cmd_buf_hold_flush(ctx);
+ 
++    // pending waits guard memory a peer blit can still be reading, so they must run and complete before synchronize returns
++    if (ctx->n_ev_wait_pending > 0 || ctx->n_peer_waits > 0) {
++        @autoreleasepool {
++            id<MTLCommandBuffer> cmd_buf = [ctx->queue commandBuffer];
++            ggml_metal_encode_pending_waits(ctx, cmd_buf);
++            ggml_metal_cmd_buf_submit(ctx, cmd_buf);
++        }
++    }
++
+     // wait for any backend operations to finish
+     if (ctx->cmd_buf_last) {
+         [ctx->cmd_buf_last waitUntilCompleted];
+         ctx->cmd_buf_last = nil;
+     }
+ 
+     // in-flight staged uploads count as pending backend operations
+     ggml_metal_device_upload_drain(ctx->dev);


### PR DESCRIPTION
# fix: Metal allreduce fail-loud + synchronize pending-wait flush (v0.86 series)

Resubmission per your request on #78 — just the two you approved, re-rolled for the flat series at `-U8` on current `main` (post-`ca3d5a3e1` port). Both patches validated to apply in numeric order on top of the seven monoliths; renumber freely.

## 0008 — comm allreduce: fail loud instead of silently wrong results

`GGML_ASSERT(ok || !reduced)` in the butterfly allreduce vanishes under NDEBUG. If a push fails **after** `reduce()` has partially run, the function returns false and the meta-backend fallback re-adds the partial sums a second time — silently wrong output. The n>2 butterfly (exercised by any 3+ device split) issues 8 pushes instead of 2, quadrupling that window.

Fix: `return false` (safe fallback, which redoes the whole allreduce) only when **nothing** was reduced; once any device has reduced, `GGML_ABORT` — the bool contract offers no other channel, and wrong results are never acceptable. The reduce loop and the tail copies to excess devices get the same treatment; all three were the same latent NDEBUG pattern.

## 0009 — synchronize: flush pending peer/event waits

`ggml_metal_peer_wait_add` queues back-edge waits into the source context's **next** command buffer, but `ggml_metal_synchronize` flushed only `cmd_buf_hold` and waited `cmd_buf_last`. A synchronize could return while a peer blit on another die still reads this context's memory — a host-side free/realloc (MoE staging resize, buffer churn) then races the in-flight remote read.

Fix: when pending waits exist, encode them into a small command buffer (the existing `ggml_metal_encode_pending_waits` + submit pattern) and include it in the wait. Deadlock-free by construction: every queued wait targets an event already signaled by a committed buffer (checked at all signal/wait sites); encoding clears the pending lists so nothing is encoded twice; empty lists skip the extra buffer entirely (behavior unchanged).

## Validation

- Both patches applied in series order over the v0.86 monoliths on `ca3d5a3e1`; resulting tree verified byte-identical against the independently built reference.
- Runtime on 4× Radeon Pro Vega II Duo (two IFL peer groups), macOS 26.6.2: gemma-3-4b Q4_K_M 4-die split completes clean at 44–50 t/s tg128 across configs, peer path exercised on both IFL pairs (`TOSH_MGPU_PEER=1`).
- Independent GPT-5.6-sol code review of both patches: **APPROVE** (all synchronization invariants checked: flush coverage, signal-before-wait ordering, no double-encoding, empty-list no-op).
