### PR TITLE
metal: wave64 ext matvec kernels for the multi-token path (GCN)

### DIFF
--- a/patches/llama/0050-metal-ext-mv-wave64-tuning.patch
+++ b/patches/llama/0050-metal-ext-mv-wave64-tuning.patch
@@ -1,0 +1,286 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.cpp b/ggml/src/ggml-metal/ggml-metal-device.cpp
+index 1e0d16d50..ee8ccc1ed 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
++++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
+@@ -844,17 +844,23 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ext(ggml_
+     if (!no_raw && tsrc0 == GGML_TYPE_Q4_K) {
+         snprintf(tname, sizeof(tname), use_lds ? "%s_raw_lds" : "%s_raw", ggml_type_name(tsrc0));
+     } else if (!no_raw && is_khdr) {
+         snprintf(tname, sizeof(tname), "%s_hdr", ggml_type_name(tsrc0));
+     } else {
+         snprintf(tname, sizeof(tname), "%s", ggml_metal_tname(lib, tsrc0));
+     }
+ 
+-    if (nr0 > 1) {
++    // q6_K on 64 lanes uses the wave64-shaped variant; TOSH_EXT_W64_DISABLE falls back to the generic kernel
++    static const bool w64_disable = getenv("TOSH_EXT_W64_DISABLE") != nullptr;
++    const bool is_w64_q6k = !w64_disable && tsrc0 == GGML_TYPE_Q6_K && simd_width_lds == 64;
++
++    if (is_w64_q6k) {
++        snprintf(base, 256, "kernel_mul_mv_ext_%s_%s_r1_%d_w64", ggml_type_name(tsrc0), ggml_type_name(tsrc1), r1ptg);
++    } else if (nr0 > 1) {
+         snprintf(base, 256, "kernel_mul_mv_ext_%s_%s_r1_%d_nr0_%d", tname, ggml_type_name(tsrc1), r1ptg, nr0);
+     } else {
+         snprintf(base, 256, "kernel_mul_mv_ext_%s_%s_r1_%d", tname, ggml_type_name(tsrc1), r1ptg);
+     }
+     snprintf(name, 256, "%s_nsg=%d_nxpsg=%d_ne12=%d_r2=%d_r3=%d", base, nsg, nxpsg, ne12, r2, r3);
+ 
+     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+     if (!res.pipeline) {
+diff --git a/ggml/src/ggml-metal/ggml-metal-ops.cpp b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+index 88140592a..6bd4de46e 100644
+--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
++++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+@@ -2994,17 +2994,23 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
+         const int16_t nr0   = nr0_2 ? (nr0_env ? nr0_env : (nr0_wide ? 4 : 2)) : 1;
+ 
+         // each group makes a full pass over the weights, so the cost is groups by group width:
+         // nine and ten columns fit in two groups of five instead of three of four
+         if (ext_wide_group(op->src[0]->type) && (ne11 == 9 || ne11 == 10)) {
+             r1ptg = 5;
+         }
+ 
+-        const int16_t r0ptg = nypsg*nsg*nr0;       // num src0 rows per threadgroup
++        // the wave64 q6_K variant keeps four rows per simdgroup, so the row split does not apply
++        // keep the gate in sync with the pipeline picker in ggml_metal_library_get_pipeline_mul_mv_ext
++        static const bool ext_w64_disable = getenv("TOSH_EXT_W64_DISABLE") != nullptr;
++        const bool ext_w64_q6k = !ext_w64_disable &&
++                                 props_dev->simd_width == 64 && op->src[0]->type == GGML_TYPE_Q6_K;
++
++        const int16_t r0ptg = ext_w64_q6k ? 4*nsg : nypsg*nsg*nr0; // num src0 rows per threadgroup
+ 
+         auto pipeline = ggml_metal_library_get_pipeline_mul_mv_ext(lib, op, nsg, nxpsg, r1ptg, nr0);
+ 
+         ggml_metal_kargs_mul_mv_ext args = {
+             /*.ne00  =*/ ne00,
+             /*.ne01  =*/ ne01,
+             /*.ne02  =*/ ne02,
+             /*.nb00  =*/ nb00,
+diff --git a/ggml/src/ggml-metal/kernels/mul_mv.metal b/ggml/src/ggml-metal/kernels/mul_mv.metal
+index a1e3e9d15..68d4ae1f5 100644
+--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
++++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
+@@ -4354,16 +4354,223 @@ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_2_nr0_4")]] kernel mul_mv_ex
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 1, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 2, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 4, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, 1, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, 2, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, 4, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, 1, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, 2, block_q6_K, 256, dequantize_q6_K>;
++
++// q6_K batched matvec for 64-lane simdgroups; the generic ext path leaves GCN latency-bound (~45 GB/s vs ~265 single-column).
++// Same block layout as kernel_mul_mv_q6_K_f32_r4, plus one accumulator per src1 row so the weights are read once.
++// With pf set, the next block's weight words are staged while the current block computes: HBM latency, not bandwidth, is the wall.
++// pf pays where the register file has headroom (r1ptg 2) or where the plain form spills (r1ptg 5); measured on gfx906.
++template<short r1ptg, short nr0, bool pf>
++kernel void kernel_mul_mv_ext_q6_K_f32_w64_disp(
++        constant ggml_metal_kargs_mul_mv_ext & args,
++        device const char * src0,
++        device const char * src1,
++        device       char * dst,
++        uint3   tgpig[[threadgroup_position_in_grid]],
++        ushort  tiisg[[thread_index_in_simdgroup]],
++        ushort  sgitg[[simdgroup_index_in_threadgroup]],
++        ushort  sgptg[[threads_per_simdgroup]]) {
++
++    const short NSG = FC_mul_mv_nsg;
++
++    constexpr uint8_t kmask1 = 0x03;
++    constexpr uint8_t kmask2 = 0x0C;
++    constexpr uint8_t kmask3 = 0x30;
++    constexpr uint8_t kmask4 = 0xC0;
++
++    const int nb = args.ne00/QK_K;
++
++    const int r0  = tgpig.x;
++    const int i11 = tgpig.y*r1ptg;
++    const int im  = tgpig.z;
++
++    const int first_row = (r0*NSG + sgitg)*nr0;
++
++    const uint i12 = im%FC_mul_mv_ne12;
++    const uint i13 = im/FC_mul_mv_ne12;
++
++    const uint64_t offset0 = first_row*args.nb01 + (i12/FC_mul_mv_r2)*args.nb02 + (i13/FC_mul_mv_r3)*args.nb03;
++    const uint64_t offset1 =        i11*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
++
++    device const block_q6_K * x  = (device const block_q6_K *) (src0 + offset0);
++    device const char       * yb = src1 + offset1;
++
++    float sumf[r1ptg][nr0];
++
++#pragma unroll
++    for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            sumf[ir1][row] = 0.0f;
++        }
++    }
++
++    const short NG  = sgptg/16;
++    const short tid = tiisg%16;
++    const short ix  = tiisg/16;
++    const short ip  = tid/8;
++    const short il  = tid%8;
++    const short l0  = 4*il;
++    const short is  = 8*ip + l0/16;
++
++    const short y_offset   = 128*ip + l0;
++    const short q_offset_l =  64*ip + l0;
++    const short q_offset_h =  32*ip + l0;
++
++    // weight words for the block in flight, one set per row
++    uint pw1[nr0], pw2[nr0], pwh[nr0];
++
++    const int i0 = ix < nb ? ix : 0;   // lanes past nb never loop; keep the prologue in bounds
++
++    if (pf) {
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            device const block_q6_K * xr = (first_row + row < args.ne01)
++                ? (device const block_q6_K *) ((device const char *) x + row*args.nb01)
++                : (device const block_q6_K *) src0;
++
++            device const ushort * s1 = (device const ushort *) (xr[i0].ql + q_offset_l);
++            device const ushort * s2 = (device const ushort *) (s1 + 16);
++            device const ushort * sh = (device const ushort *) (xr[i0].qh + q_offset_h);
++
++            pw1[row] = (uint) s1[0] | ((uint) s1[1] << 16);
++            pw2[row] = (uint) s2[0] | ((uint) s2[1] << 16);
++            pwh[row] = (uint) sh[0] | ((uint) sh[1] << 16);
++        }
++    }
++
++    for (int i = ix; i < nb; i += NG) {
++        // activation tiles for this block, hoisted out of the row loop and read as float4
++        float4 y4[r1ptg][4];
++
++#pragma unroll
++        for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++            device const float4 * yc = (device const float4 *) (yb + (i11 + ir1 < args.ne11 ? ir1*args.nb11 : 0));
++            device const float4 * y  = yc + i*(QK_K/4) + y_offset/4;
++
++            FOR_UNROLL (short j = 0; j < 4; ++j) {
++                y4[ir1][j] = y[j*8];
++            }
++        }
++
++        // stage the next block's weight words before computing this one: the loads
++        // then have a full iteration of compute to complete. The last iteration
++        // restages the final block (L1 hit) instead of branching
++        uint nw1[nr0], nw2[nr0], nwh[nr0];
++
++        if (pf) {
++            const int inext = i + NG < nb ? i + NG : nb - 1;
++
++#pragma unroll
++            for (short row = 0; row < nr0; ++row) {
++                device const block_q6_K * xr = (first_row + row < args.ne01)
++                    ? (device const block_q6_K *) ((device const char *) x + row*args.nb01)
++                    : (device const block_q6_K *) src0;
++
++                device const ushort * s1 = (device const ushort *) (xr[inext].ql + q_offset_l);
++                device const ushort * s2 = (device const ushort *) (s1 + 16);
++                device const ushort * sh = (device const ushort *) (xr[inext].qh + q_offset_h);
++
++                nw1[row] = (uint) s1[0] | ((uint) s1[1] << 16);
++                nw2[row] = (uint) s2[0] | ((uint) s2[1] << 16);
++                nwh[row] = (uint) sh[0] | ((uint) sh[1] << 16);
++            }
++        }
++
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            // rows past ne01 fall back to row zero; their sums are dropped at the store
++            device const block_q6_K * xr = (first_row + row < args.ne01)
++                ? (device const block_q6_K *) ((device const char *) x + row*args.nb01)
++                : (device const block_q6_K *) src0;
++
++            device const int8_t  * sc = xr[i].scales + is;
++            device const half    * dh = &xr[i].d;
++
++            uint w1, w2, wh;
++
++            if (pf) {
++                w1 = pw1[row];
++                w2 = pw2[row];
++                wh = pwh[row];
++            } else {
++                device const ushort * s1 = (device const ushort *) (xr[i].ql + q_offset_l);
++                device const ushort * s2 = (device const ushort *) (s1 + 16);
++                device const ushort * sh = (device const ushort *) (xr[i].qh + q_offset_h);
++
++                w1 = (uint) s1[0] | ((uint) s1[1] << 16);
++                w2 = (uint) s2[0] | ((uint) s2[1] << 16);
++                wh = (uint) sh[0] | ((uint) sh[1] << 16);
++            }
++
++            // int-to-float via the exponent trick: full-rate ops, exact for v in [0, 63]
++            float4 v4[4];
++
++            FOR_UNROLL (short l = 0; l < 4; ++l) {
++                const uint8_t b1 = (uint8_t)(w1 >> (8*l));
++                const uint8_t b2 = (uint8_t)(w2 >> (8*l));
++                const uint8_t bh = (uint8_t)(wh >> (8*l));
++
++                v4[0][l] = as_type<float>(0x4B000000u | (uint)((b1 & 0xF) | ((bh & kmask1) << 4))) - 8388640.0f;
++                v4[1][l] = as_type<float>(0x4B000000u | (uint)((b2 & 0xF) | ((bh & kmask2) << 2))) - 8388640.0f;
++                v4[2][l] = as_type<float>(0x4B000000u | (uint)((b1  >> 4) | ((bh & kmask3) << 0))) - 8388640.0f;
++                v4[3][l] = as_type<float>(0x4B000000u | (uint)((b2  >> 4) | ((bh & kmask4) >> 2))) - 8388640.0f;
++            }
++
++            const float4 dsc = (float) dh[0] * (float4) { (float) sc[0], (float) sc[2], (float) sc[4], (float) sc[6] };
++
++#pragma unroll
++            for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++                float4 sums = {0.f, 0.f, 0.f, 0.f};
++
++                FOR_UNROLL (short j = 0; j < 4; ++j) {
++                    sums[j] = dot(y4[ir1][j], v4[j]);
++                }
++
++                sumf[ir1][row] += sums[0]*dsc[0] + sums[1]*dsc[1] + sums[2]*dsc[2] + sums[3]*dsc[3];
++            }
++        }
++
++        if (pf) {
++#pragma unroll
++            for (short row = 0; row < nr0; ++row) {
++                pw1[row] = nw1[row];
++                pw2[row] = nw2[row];
++                pwh[row] = nwh[row];
++            }
++        }
++    }
++
++    device float * dst_f32 = (device float *) dst + (uint64_t)im*args.ne0*args.ne1 + (uint64_t)i11*args.ne0;
++
++#pragma unroll
++    for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            const float sum_all = simd_sum(sumf[ir1][row]);
++            if (tiisg == 0 && i11 + ir1 < args.ne11 && first_row + row < args.ne01) {
++                dst_f32[ir1*args.ne0 + first_row + row] = sum_all;
++            }
++        }
++    }
++}
++
++typedef decltype(kernel_mul_mv_ext_q6_K_f32_w64_disp<2, 4, true>) mul_mv_ext_q6_K_w64_t;
++
++template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_2_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<2, 4, true>;
++template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<3, 4, false>;
++template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<4, 4, false>;
++template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<5, 4, true>;
++
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, 4, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 1, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 2, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 4, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 1, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 2, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 4, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, 1, block_q2_K, 256, dequantize_q2_K>;

--- a/patches/llama/0051-metal-ext-mv-wave64-single-pass.patch
+++ b/patches/llama/0051-metal-ext-mv-wave64-single-pass.patch
@@ -1,0 +1,197 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-ops.cpp b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+index 6bd4de46e..f17e81f5b 100644
+--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
++++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+@@ -3000,17 +3000,22 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
+         }
+ 
+         // the wave64 q6_K variant keeps four rows per simdgroup, so the row split does not apply
+         // keep the gate in sync with the pipeline picker in ggml_metal_library_get_pipeline_mul_mv_ext
+         static const bool ext_w64_disable = getenv("TOSH_EXT_W64_DISABLE") != nullptr;
+         const bool ext_w64_q6k = !ext_w64_disable &&
+                                  props_dev->simd_width == 64 && op->src[0]->type == GGML_TYPE_Q6_K;
+ 
+-        const int16_t r0ptg = ext_w64_q6k ? 4*nsg : nypsg*nsg*nr0; // num src0 rows per threadgroup
++        // from six src1 rows the eight-column variant reads the weights once instead of twice
++        if (ext_w64_q6k && ne11 >= 6) {
++            r1ptg = 8;
++        }
++
++        const int16_t r0ptg = ext_w64_q6k ? (r1ptg == 8 ? 2 : 4)*nsg : nypsg*nsg*nr0; // num src0 rows per threadgroup
+ 
+         auto pipeline = ggml_metal_library_get_pipeline_mul_mv_ext(lib, op, nsg, nxpsg, r1ptg, nr0);
+ 
+         ggml_metal_kargs_mul_mv_ext args = {
+             /*.ne00  =*/ ne00,
+             /*.ne01  =*/ ne01,
+             /*.ne02  =*/ ne02,
+             /*.nb00  =*/ nb00,
+diff --git a/ggml/src/ggml-metal/kernels/mul_mv.metal b/ggml/src/ggml-metal/kernels/mul_mv.metal
+index 68d4ae1f5..086eefbb6 100644
+--- a/ggml/src/ggml-metal/kernels/mul_mv.metal
++++ b/ggml/src/ggml-metal/kernels/mul_mv.metal
+@@ -4560,16 +4560,164 @@ kernel void kernel_mul_mv_ext_q6_K_f32_w64_disp(
+ }
+ 
+ typedef decltype(kernel_mul_mv_ext_q6_K_f32_w64_disp<2, 4, true>) mul_mv_ext_q6_K_w64_t;
+ 
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_2_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<2, 4, true>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_3_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<3, 4, false>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_4_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<4, 4, false>;
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5_w64")]] kernel mul_mv_ext_q6_K_w64_t kernel_mul_mv_ext_q6_K_f32_w64_disp<5, 4, true>;
++// eight src1 rows in one weight pass: dequantized block values live across both
++// four-column activation windows, so the register cost stays near the four-column
++// kernel while the second group no longer re-reads the weights. Two rows per lane.
++[[host_name("kernel_mul_mv_ext_q6_K_f32_r1_8_w64")]]
++kernel void kernel_mul_mv_ext_q6_K_f32_w64x8(
++        constant ggml_metal_kargs_mul_mv_ext & args,
++        device const char * src0,
++        device const char * src1,
++        device       char * dst,
++        uint3   tgpig[[threadgroup_position_in_grid]],
++        ushort  tiisg[[thread_index_in_simdgroup]],
++        ushort  sgitg[[simdgroup_index_in_threadgroup]],
++        ushort  sgptg[[threads_per_simdgroup]]) {
++    constexpr short nr0  = 2;
++    constexpr short r1ptg = 8;
++    constexpr short cch  = 4;   // columns per activation window
++
++    const short NSG = FC_mul_mv_nsg;
++
++    constexpr uint8_t kmask1 = 0x03;
++    constexpr uint8_t kmask2 = 0x0C;
++    constexpr uint8_t kmask3 = 0x30;
++    constexpr uint8_t kmask4 = 0xC0;
++
++    const int nb = args.ne00/QK_K;
++
++    const int r0  = tgpig.x;
++    const int i11 = tgpig.y*r1ptg;
++    const int im  = tgpig.z;
++
++    const int first_row = (r0*NSG + sgitg)*nr0;
++
++    const uint i12 = im%FC_mul_mv_ne12;
++    const uint i13 = im/FC_mul_mv_ne12;
++
++    const uint64_t offset0 = first_row*args.nb01 + (i12/FC_mul_mv_r2)*args.nb02 + (i13/FC_mul_mv_r3)*args.nb03;
++    const uint64_t offset1 =        i11*args.nb11 + (i12        )*args.nb12 + (i13        )*args.nb13;
++
++    device const block_q6_K * x  = (device const block_q6_K *) (src0 + offset0);
++    device const char       * yb = src1 + offset1;
++
++    float sumf[r1ptg][nr0];
++
++#pragma unroll
++    for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            sumf[ir1][row] = 0.0f;
++        }
++    }
++
++    const short NG  = sgptg/16;
++    const short tid = tiisg%16;
++    const short ix  = tiisg/16;
++    const short ip  = tid/8;
++    const short il  = tid%8;
++    const short l0  = 4*il;
++    const short is  = 8*ip + l0/16;
++
++    const short y_offset   = 128*ip + l0;
++    const short q_offset_l =  64*ip + l0;
++    const short q_offset_h =  32*ip + l0;
++
++    for (int i = ix; i < nb; i += NG) {
++        // dequant the block for both rows before the activation windows load
++        float4 v4r[nr0][4];
++        float4 dscr[nr0];
++
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            // rows past ne01 fall back to row zero; their sums are dropped at the store
++            device const block_q6_K * xr = (first_row + row < args.ne01)
++                ? (device const block_q6_K *) ((device const char *) x + row*args.nb01)
++                : (device const block_q6_K *) src0;
++
++            device const uint8_t * q1 = xr[i].ql + q_offset_l;
++            device const uint8_t * q2 = q1 + 32;
++            device const uint8_t * qh = xr[i].qh + q_offset_h;
++            device const int8_t  * sc = xr[i].scales + is;
++            device const half    * dh = &xr[i].d;
++
++            device const ushort * s1 = (device const ushort *) q1;
++            device const ushort * s2 = (device const ushort *) q2;
++            device const ushort * sh = (device const ushort *) qh;
++
++            const uint w1 = (uint) s1[0] | ((uint) s1[1] << 16);
++            const uint w2 = (uint) s2[0] | ((uint) s2[1] << 16);
++            const uint wh = (uint) sh[0] | ((uint) sh[1] << 16);
++
++            // int-to-float via the exponent trick: full-rate ops, exact for v in [0, 63]
++            FOR_UNROLL (short l = 0; l < 4; ++l) {
++                const uint8_t b1 = (uint8_t)(w1 >> (8*l));
++                const uint8_t b2 = (uint8_t)(w2 >> (8*l));
++                const uint8_t bh = (uint8_t)(wh >> (8*l));
++
++                v4r[row][0][l] = as_type<float>(0x4B000000u | (uint)((b1 & 0xF) | ((bh & kmask1) << 4))) - 8388640.0f;
++                v4r[row][1][l] = as_type<float>(0x4B000000u | (uint)((b2 & 0xF) | ((bh & kmask2) << 2))) - 8388640.0f;
++                v4r[row][2][l] = as_type<float>(0x4B000000u | (uint)((b1  >> 4) | ((bh & kmask3) << 0))) - 8388640.0f;
++                v4r[row][3][l] = as_type<float>(0x4B000000u | (uint)((b2  >> 4) | ((bh & kmask4) >> 2))) - 8388640.0f;
++            }
++
++            dscr[row] = (float) dh[0] * (float4) { (float) sc[0], (float) sc[2], (float) sc[4], (float) sc[6] };
++        }
++
++#pragma unroll
++        for (short c0 = 0; c0 < r1ptg; c0 += cch) {
++            float4 y4[cch][4];
++
++#pragma unroll
++            for (short ir1 = 0; ir1 < cch; ++ir1) {
++                device const float4 * yc = (device const float4 *) (yb + (i11 + c0 + ir1 < args.ne11 ? (uint64_t)(c0 + ir1)*args.nb11 : 0));
++                device const float4 * y  = yc + i*(QK_K/4) + y_offset/4;
++
++                FOR_UNROLL (short j = 0; j < 4; ++j) {
++                    y4[ir1][j] = y[j*8];
++                }
++            }
++
++#pragma unroll
++            for (short row = 0; row < nr0; ++row) {
++#pragma unroll
++                for (short ir1 = 0; ir1 < cch; ++ir1) {
++                    float4 sums = {0.f, 0.f, 0.f, 0.f};
++
++                    FOR_UNROLL (short j = 0; j < 4; ++j) {
++                        sums[j] = dot(y4[ir1][j], v4r[row][j]);
++                    }
++
++                    sumf[c0 + ir1][row] += sums[0]*dscr[row][0] + sums[1]*dscr[row][1] + sums[2]*dscr[row][2] + sums[3]*dscr[row][3];
++                }
++            }
++        }
++    }
++
++    device float * dst_f32 = (device float *) dst + (uint64_t)im*args.ne0*args.ne1 + (uint64_t)i11*args.ne0;
++
++#pragma unroll
++    for (short ir1 = 0; ir1 < r1ptg; ++ir1) {
++#pragma unroll
++        for (short row = 0; row < nr0; ++row) {
++            const float sum_all = simd_sum(sumf[ir1][row]);
++            if (tiisg == 0 && i11 + ir1 < args.ne11 && first_row + row < args.ne01) {
++                dst_f32[ir1*args.ne0 + first_row + row] = sum_all;
++            }
++        }
++    }
++}
++
+ 
+ template [[host_name("kernel_mul_mv_ext_q6_K_f32_r1_5_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, 4, block_q6_K, 256, dequantize_q6_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 1, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 2, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_2_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, 4, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 1, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3_nr0_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 2, block_q2_K, 256, dequantize_q2_K>;
+ template [[host_name("kernel_mul_mv_ext_q2_K_f32_r1_3_nr0_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, 4, block_q2_K, 256, dequantize_q2_K>;


### PR DESCRIPTION
# metal: wave64 ext matvec kernels for the multi-token path (GCN)

## TL;DR

The 64-lane pass in 0.87 (0041-0046) covers single-token decode, experts, fused matvec and prefill attention — but not the **multi-token ext path** (`kernel_mul_mv_ext_*`, ne11 2-12: speculative verify, small-batch decode, perplexity windows). On GCN that path still runs the wave32-era ext kernels, which we measured at **~45 GB/s effective** where the wave64-native single-token path sustains ~265 GB/s. These two patches add wave64-native ext kernels. DFlash2 verify end-to-end on 4x gfx906: **9.4 -> 12.5 t/s** (+33%), now above the plain-decode floor; verify-graph wall 494 -> ~273 ms.

Patches (one per change): `0050-metal-ext-mv-wave64-tuning.patch` (the base `w64_disp` kernel, r1ptg 2-5, selective software-pipelined weight staging) and `0051-metal-ext-mv-wave64-single-pass.patch` (`w64x8`: 8 rows per threadgroup, one weight pass for ne11 >= 6, dequant shared across two 4-column windows). Both are gated `simd_width == 64 && Q6_K`, with `TOSH_EXT_W64_DISABLE` falling back to the previous path; wave32 and Apple Silicon dispatch are untouched.

## Measurements (2x Radeon Pro Vega II Duo = 4x gfx906 dies, macOS 26.6.2)

Microbench (m=4096, k=14336, Q6_K, us/run):

| ne11 | old ext | 0050 | +0051 |
|---|---|---|---|
| 2 | 593-ish (see note) | **167.9** | 167.9 |
| 5 | 593.0 | 454.9 -> **354.1** | 354.1 |
| 8 | 610.6 (two-pass equivalent) | 610.6 | **513.5** |

(0050's win is biggest where the old config split a 64-lane group badly; 0051's single-pass wins at ne11>=6 where the two-pass form re-read weights.)

End-to-end (Qwen3.8-27B Q6_K + DFlash2 draft, fixed prompt/seed, single die): 9.4 t/s before the series, **12.5 t/s** on current main + these patches; `TOSH_EXT_W64_DISABLE=1` on the same build: 9.7 t/s — the delta is these kernels. Plain decode and Q4_K controls unchanged; perplexity A/B identical (1.0038 +/- 0.00065 both ways); generated text bit-identical; test-backend-ops MUL_MAT 1062/1062 on Metal (incl. ne11 2-9 vs CPU and partial-group guards).

Variations we measured and rejected (so they don't get re-tried): lane-half colgroup splits (halve in-flight weight streams — tie at n=8, lose at n=5), prefetch on the x8 form (register pressure), scalar-y (instruction-bound, 5x worse). The kernel is dequant-ALU-bound after these patches; further gains need lower per-byte ALU, not more passes.

## Notes

- Ext-path only; no interaction with the 0041-0046 single-token work (verified: those patches contain no mul_mv_ext changes).
- Independent reviews: codex (gpt-5.6-sol) SHIP on both after one comment-style round; re-reviewed pre-submission by codex gpt-6-astra: SHIP on both, no findings.
- Numbering/renumber freely per the series rules.
