### PR TITLE
build: stub tosh_moe_off_active for TOSH_ENABLE_DYNAMIC_MOE=OFF

### DIFF
--- a/patches/llama/0054-metal-moe-off-active-stub.patch
+++ b/patches/llama/0054-metal-moe-off-active-stub.patch
@@ -1,0 +1,22 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-ops.cpp b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+index f17e81f5b..6385bf9cc 100644
+--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
++++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
+@@ -15,16 +15,17 @@ static inline int tosh_moe_off_slot_for_id(int, int, int)  { return 0; }
+ static inline int tosh_moe_off_cold_for_id(int, int, int)  { return 0; }
+ static inline int tosh_moe_off_id_of_slot(int, int, int)   { return 0; }
+ static inline int tosh_moe_off_usage(int, int, int)        { return 0; }
+ static inline int tosh_moe_off_step(int, int, int)         { return 0; }
+ static inline int tosh_moe_off_n_indices(int, int, int)    { return 0; }
+ static inline int tosh_moe_off_evict(int, int, int)        { return 0; }
+ static inline int tosh_moe_off_src(int, int, int)          { return 0; }
+ static inline int tosh_moe_off_ids(int, int, int)          { return 0; }
++static inline int tosh_moe_off_active(int, int, int)       { return 0; }
+ #endif
+ 
+ #include "ggml.h"
+ #include "ggml-impl.h"
+ #include "ggml-backend-impl.h"
+ 
+ #include "ggml-metal-impl.h"
+ #include "ggml-metal-common.h"


### PR DESCRIPTION
# build: MoE-OFF stub for tosh_moe_off_active (0054)

## TL;DR

Same class as the stubs you folded from #79: the MoE compact-assemble path added in the 0.86.3+ series calls `tosh_moe_off_active()`, which has no stub in the `TOSH_ENABLE_DYNAMIC_MOE=OFF` `#else` block, so a default-config build of the vendored tree fails with `use of undeclared identifier` (ggml-metal-ops.cpp:3295 on the current pin). One-line stub, return 0; the call sites are runtime-dead under OFF (the whole compact-assemble path is gated on MoE being active), so behavior is unchanged in both configurations.

`patches/llama/0054-metal-moe-off-active-stub.patch` — renumber freely.

## Validation

- OFF and ON builds both compile clean on macOS 26.6.2 (Vega II Duo rig) and on Linux/CUDA.
- Pre-submission review by codex (gpt-6-astra): SHIP, no findings.
